### PR TITLE
feat: update apollo-graphql to v2 and add formatError feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ run
 test/fixtures/apps/model-app/run/
 .vscode/
 yarn.lock
+yarn-error.log

--- a/app/middleware/graphql.js
+++ b/app/middleware/graphql.js
@@ -1,6 +1,37 @@
 'use strict';
 
-const { graphqlKoa, graphiqlKoa } = require('apollo-server-koa');
+// Notice that this path is totally changed, because this function isn't
+// directly exposed to the public, now we must still use that for the middle-
+// ware.
+const { graphqlKoa } = require('apollo-server-koa/dist/koaApollo');
+
+// This has been newly imported, because in v2 of apollo-server, this is removed.
+const { resolveGraphiQLString } = require('apollo-server-module-graphiql');
+
+/**
+ This function is directly copied from:
+ https://github.com/apollographql/apollo-server/blob/300c0cd12b56be439b206d55131e1b93a9e6dade/packages/apollo-server-koa/src/koaApollo.ts#L51
+
+ And now this has been removed since v2 at:
+ https://github.com/apollographql/apollo-server/commit/dbaa465646b0acb839860a85bfd68fb4379d64ab#diff-64af8fdf76996fa3ed4e498d44124800
+
+ So we must keep this here to be compatible with what it was before.
+ Thus users can directly use that by upgrading graphql to the v2 WITHOUT
+ doing any other big changes.
+
+ * @param {Object} options The `options` of graphiqlKoa.
+ * @return {Promise} The result of the graphiqlKoa.
+ */
+function graphiqlKoa(options) {
+  return ctx => {
+    const query = ctx.request.query;
+    return resolveGraphiQLString(query, options, ctx)
+      .then(graphiqlString => {
+        ctx.set('Content-Type', 'text/html');
+        ctx.body = graphiqlString;
+      });
+  };
+}
 
 module.exports = (_, app) => {
   const options = app.config.graphql;

--- a/app/middleware/graphql.js
+++ b/app/middleware/graphql.js
@@ -1,7 +1,40 @@
 'use strict';
 
-const { graphqlKoa, graphiqlKoa } = require('apollo-server-koa');
+// Notice that this path is totally changed, because this function isn't
+// directly exposed to the public, now we must still use that for the middle-
+// ware.
+const { graphqlKoa } = require('apollo-server-koa/dist/koaApollo');
+const { FormatErrorExtension } = require('apollo-server-core/dist/formatters');
+
+// This has been newly imported, because in v2 of apollo-server, this is removed.
+const { resolveGraphiQLString } = require('apollo-server-module-graphiql');
+
 const { koa: voyagerMiddleware } = require('graphql-voyager/middleware');
+
+/**
+ This function is directly copied from:
+ https://github.com/apollographql/apollo-server/blob/300c0cd12b56be439b206d55131e1b93a9e6dade/packages/apollo-server-koa/src/koaApollo.ts#L51
+
+ And now this has been removed since v2 at:
+ https://github.com/apollographql/apollo-server/commit/dbaa465646b0acb839860a85bfd68fb4379d64ab#diff-64af8fdf76996fa3ed4e498d44124800
+
+ So we must keep this here to be compatible with what it was before.
+ Thus users can directly use that by upgrading graphql to the v2 WITHOUT
+ doing any other big changes.
+
+ * @param {Object} options The `options` of graphiqlKoa.
+ * @return {Promise} The result of the graphiqlKoa.
+ */
+function graphiqlKoa(options) {
+  return ctx => {
+    const query = ctx.request.query;
+    return resolveGraphiQLString(query, options, ctx)
+      .then(graphiqlString => {
+        ctx.set('Content-Type', 'text/html');
+        ctx.body = graphiqlString;
+      });
+  };
+}
 
 module.exports = (_, app) => {
   const options = app.config.graphql;
@@ -17,6 +50,15 @@ module.exports = (_, app) => {
   let voyager = true;
   if (options.voyager === false) {
     voyager = false;
+  }
+
+  const extensions = [];
+  if (options.formatError && typeof options.formatError === 'function') {
+    const formatErrorExtension = () => new FormatErrorExtension(
+      options.formatError,
+      options.debug,
+    );
+    extensions.push(formatErrorExtension);
   }
 
   return async (ctx, next) => {
@@ -36,12 +78,12 @@ module.exports = (_, app) => {
       return graphqlKoa({
         schema: app.schema,
         context: ctx,
-        formatError: options.formatError,
+        extensions,
       })(ctx);
     } else if (voyager && ctx.path === voyagerRouter) {
       return voyagerMiddleware({
         endpointURL: options.graphiqlRouter,
-      })(ctx);
+      })(ctx, next);
     }
     await next();
   };

--- a/app/middleware/graphql.js
+++ b/app/middleware/graphql.js
@@ -1,15 +1,22 @@
 'use strict';
 
 const { graphqlKoa, graphiqlKoa } = require('apollo-server-koa');
+const { koa: voyagerMiddleware } = require('graphql-voyager/middleware');
 
 module.exports = (_, app) => {
   const options = app.config.graphql;
   const graphQLRouter = options.router;
   options.graphiqlRouter = options.graphiqlRouter ? options.graphiqlRouter : graphQLRouter;
+  const voyagerRouter = options.voyagerRouter;
   let graphiql = true;
 
   if (options.graphiql === false) {
     graphiql = false;
+  }
+
+  let voyager = true;
+  if (options.voyager === false) {
+    voyager = false;
   }
 
   return async (ctx, next) => {
@@ -29,6 +36,11 @@ module.exports = (_, app) => {
       return graphqlKoa({
         schema: app.schema,
         context: ctx,
+        formatError: options.formatError,
+      })(ctx);
+    } else if (voyager && ctx.path === voyagerRouter) {
+      return voyagerMiddleware({
+        endpointURL: options.graphiqlRouter,
       })(ctx);
     }
     await next();

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -2,4 +2,6 @@
 
 exports.graphql = {
   router: '/graphql',
+  voyagerRouter: '/graphdoc',
+  debug: true,
 };

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "orm"
   ],
   "dependencies": {
-    "apollo-server-koa": "^1.2.0",
-    "graphql": "^0.11.7",
-    "graphql-tag": "^2.5.0",
-    "graphql-tools": "^2.19.0",
-    "lodash": "4.17.4"
+    "apollo-server-koa": "^2.0.4",
+    "apollo-server-module-graphiql": "^1.4.0",
+    "graphql": "^0.13.2",
+    "graphql-tag": "^2.9.2",
+    "graphql-tools": "^3.1.1",
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "autod": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "egg-graphql",
-  "version": "2.2.0",
+  "name": "@server/egg-graphql",
+  "version": "2.0.4",
   "description": "egg graphql plugin",
   "eggPlugin": {
     "name": "graphql"
@@ -13,12 +13,13 @@
     "orm"
   ],
   "dependencies": {
-    "apollo-server-koa": "^1.2.0",
-    "graphql": "^0.11.7",
-    "graphql-tag": "^2.5.0",
-    "graphql-tools": "^2.19.0",
+    "apollo-server-koa": "^2.0.4",
+    "apollo-server-module-graphiql": "^1.4.0",
+    "graphql": "^0.13.2",
+    "graphql-tag": "^2.9.2",
+    "graphql-tools": "^3.1.1",
     "graphql-voyager": "^1.0.0-rc.25",
-    "lodash": "4.17.4"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "autod": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-graphql",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "egg graphql plugin",
   "eggPlugin": {
     "name": "graphql"
@@ -17,6 +17,7 @@
     "graphql": "^0.11.7",
     "graphql-tag": "^2.5.0",
     "graphql-tools": "^2.19.0",
+    "graphql-voyager": "^1.0.0-rc.25",
     "lodash": "4.17.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@server/egg-graphql",
+  "name": "egg-graphql",
   "version": "2.0.4",
   "description": "egg graphql plugin",
   "eggPlugin": {

--- a/test/app/graphiql/closeGraphiql.test.js
+++ b/test/app/graphiql/closeGraphiql.test.js
@@ -15,7 +15,7 @@ describe('test/closeGraphiql.test.js', () => {
 
   after(mm.restore);
 
-  it('should get graphql json response', function* () {
+  it('should get graphql json response', async () => {
     app.mockHttpclient('/graphql', 'GET', {
       headers: {
         'accept-language': 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
@@ -23,7 +23,8 @@ describe('test/closeGraphiql.test.js', () => {
         'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:57.0) Gecko/20100101 Firefox/57.0',
       },
     });
-    return app.httpRequest()
+
+    await app.httpRequest()
       .get('/graphql')
       .expect('GET query missing.');
   });

--- a/test/app/graphiql/graphiql.test.js
+++ b/test/app/graphiql/graphiql.test.js
@@ -15,14 +15,13 @@ describe('test/graphiql.test.js', () => {
 
   after(mm.restore);
 
-  it('should get graphiql html response', function* () {
+  it('should get graphiql html response', async () => {
     app.mockHttpclient('/graphql', 'GET', {});
-    return app.httpRequest()
+    const result = await app.httpRequest()
       .get('/graphql')
       .set('Accept', 'text/html')
-      .expect(200)
-      .then(response => {
-        assert(response.type, 'text/html');
-      });
+      .expect(200);
+
+    assert(result.type, 'text/html');
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
1. update `apollo-graphql` to v2
2. add `formarError` in config, for customize error handling. Useful in graphql error tracking.